### PR TITLE
Styling Ordered List &  Unordered List

### DIFF
--- a/basil.css
+++ b/basil.css
@@ -1461,3 +1461,45 @@ Created by Daniel Bergmann, built by the community.
     text-align: left;
   }
 }
+
+
+/* Ordered List &  Unordered List*/
+
+/* Resetting margins and paddings */
+ul,
+ol {
+  margin-left: var(--md);
+  margin-bottom: var(--md);
+  list-style-position: inside;
+  font-family: Assistant,sans-serif;
+  color: var(--primary);
+  line-height: 1.5;
+}
+
+ul {
+  list-style-type: disc;
+  /* Default, set for clarity */
+}
+
+ol {
+  list-style-type: decimal;
+  /* Default, set for clarity */
+}
+
+ul ul,
+ol ol,
+ul ol,
+ol ul {
+  margin-top: var(--sm);
+  margin-left: var(--lg);
+}
+
+li {
+  margin-bottom: var(--sm);
+  transition: all 0.3s ease-in-out;
+}
+
+li:hover {
+  color: var(--accent);
+  padding-left: var(--sm);
+}


### PR DESCRIPTION
I've removed default browser styles for <ul> and <ol>, applying consistent margins with Basil's predefined variables. Additionally, I've ensured the lists use the Assistant, sans-serif font family. For better visuals, added margins have been set for nested lists. To enhance user experience, added hover effects on list items using the --accent color, complemented with left-padding.